### PR TITLE
fix when a long rich text error of notion rich_text api (should be less than 2000 chars)

### DIFF
--- a/src/store/notion.js
+++ b/src/store/notion.js
@@ -29,7 +29,8 @@ const FORMATS = {
     ]
   },
   rich_text(val) {
-    return this.title(val);
+    val_fitin = val.length <= 2000 ? val : val.substring(0, 2000);
+    return this.title(val_fitin);
   },
   number(val) {
     return Number(val);

--- a/src/store/notion.js
+++ b/src/store/notion.js
@@ -29,8 +29,8 @@ const FORMATS = {
     ]
   },
   rich_text(val) {
-    val_fitin = val.length <= 2000 ? val : val.substring(0, 2000);
-    return this.title(val_fitin);
+    const valFitin = val.length <= 2000 ? val : val.substring(0, 2000);
+    return this.title(valFitin);
   },
   number(val) {
     return Number(val);


### PR DESCRIPTION
When the length of rich text of notion property is greater than 2000 chars, the api returns error. This patch fixes this situation. 

see https://github.com/lizheming/doumark-action/issues/11